### PR TITLE
Fix Claude workflow trigger from bot comments

### DIFF
--- a/.github/workflows/claude-manual-trigger.yml
+++ b/.github/workflows/claude-manual-trigger.yml
@@ -1,0 +1,49 @@
+name: Claude Manual Trigger
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to comment on'
+        required: false
+        type: string
+      issue_number:
+        description: 'Issue number to comment on'
+        required: false
+        type: string
+      comment_body:
+        description: 'Comment body (must include @claude)'
+        required: true
+        default: '@claude implement this feature based on the PR description'
+        type: string
+
+jobs:
+  trigger-claude:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create comment to trigger Claude
+        env:
+          # Use a PAT from a real user account, not github-actions bot
+          GITHUB_TOKEN: ${{ secrets.CLAUDE_TRIGGER_TOKEN }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+          COMMENT_BODY: ${{ github.event.inputs.comment_body }}
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Creating comment on PR #$PR_NUMBER"
+            curl -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
+              -d "{\"body\": \"$COMMENT_BODY\"}"
+          elif [ -n "$ISSUE_NUMBER" ]; then
+            echo "Creating comment on Issue #$ISSUE_NUMBER"
+            curl -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments \
+              -d "{\"body\": \"$COMMENT_BODY\"}"
+          else
+            echo "❌ Either pr_number or issue_number must be provided"
+            exit 1
+          fi

--- a/.github/workflows/linear-integration.yml
+++ b/.github/workflows/linear-integration.yml
@@ -329,7 +329,7 @@ jobs:
         
       - name: Add Claude comment to issue
         env:
-          GITHUB_TOKEN: ${{ secrets.CLAUDE_TRIGGER_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ needs.process-claude-ready.outputs.issue_number }}
         run: |
           echo "📝 Adding Claude comment to GitHub issue #$ISSUE_NUMBER"
@@ -346,17 +346,20 @@ jobs:
             COMMENT_BODY="@claude Implement this based on the issue description above"
           fi
           
-          # Use API directly if CLAUDE_TRIGGER_TOKEN is available, otherwise use gh CLI
+          # First, add a regular comment for visibility
+          gh issue comment $ISSUE_NUMBER --body "$COMMENT_BODY"
+          
+          # If CLAUDE_TRIGGER_TOKEN exists, trigger the manual workflow
           if [ -n "${{ secrets.CLAUDE_TRIGGER_TOKEN }}" ]; then
-            echo "Using GitHub API with PAT to create comment"
+            echo "Triggering Claude manually via workflow_dispatch"
             curl -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Authorization: token ${{ secrets.CLAUDE_TRIGGER_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
-              https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments \
-              -d "{\"body\": \"$COMMENT_BODY\"}"
+              https://api.github.com/repos/${{ github.repository }}/actions/workflows/claude-manual-trigger.yml/dispatches \
+              -d "{\"ref\": \"main\", \"inputs\": {\"issue_number\": \"$ISSUE_NUMBER\", \"comment_body\": \"$COMMENT_BODY\"}}"
+            echo "✅ Triggered Claude workflow for issue #$ISSUE_NUMBER"
           else
-            echo "Using gh CLI to create comment (won't trigger Claude)"
-            gh issue comment $ISSUE_NUMBER --body "$COMMENT_BODY"
+            echo "⚠️ CLAUDE_TRIGGER_TOKEN not set - Claude won't be triggered automatically"
           fi
           echo "✅ Added Claude comment to issue #$ISSUE_NUMBER"
 
@@ -556,7 +559,7 @@ jobs:
         
       - name: Add Claude comment to PR
         env:
-          GITHUB_TOKEN: ${{ secrets.CLAUDE_TRIGGER_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ needs.process-linear-pr.outputs.pr_number }}
           BRANCH_NAME: ${{ needs.process-linear-pr.outputs.branch_name }}
         run: |
@@ -577,17 +580,19 @@ jobs:
           
           COMMENT_BODY="@claude implement this feature based on the PR description"
           
-          # Use API directly if CLAUDE_TRIGGER_TOKEN is available, otherwise use gh CLI
+          # First, add a regular comment for visibility
+          gh pr comment $PR_NUMBER --body "$COMMENT_BODY"
+          
+          # If CLAUDE_TRIGGER_TOKEN exists, trigger the manual workflow
           if [ -n "${{ secrets.CLAUDE_TRIGGER_TOKEN }}" ]; then
-            echo "Using GitHub API with PAT to create comment"
+            echo "Triggering Claude manually via workflow_dispatch"
             curl -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Authorization: token ${{ secrets.CLAUDE_TRIGGER_TOKEN }}" \
               -H "Accept: application/vnd.github.v3+json" \
-              https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
-              -d "{\"body\": \"$COMMENT_BODY\"}"
+              https://api.github.com/repos/${{ github.repository }}/actions/workflows/claude-manual-trigger.yml/dispatches \
+              -d "{\"ref\": \"main\", \"inputs\": {\"pr_number\": \"$PR_NUMBER\", \"comment_body\": \"$COMMENT_BODY\"}}"
+            echo "✅ Triggered Claude workflow for PR #$PR_NUMBER"
           else
-            echo "Using gh CLI to create comment (won't trigger Claude)"
-            gh pr comment $PR_NUMBER --body "$COMMENT_BODY"
+            echo "⚠️ CLAUDE_TRIGGER_TOKEN not set - Claude won't be triggered automatically"
           fi
-          echo "✅ Added Claude comment to PR #$PR_NUMBER"
 


### PR DESCRIPTION
## Summary

This PR fixes the issue where GitHub Actions bot comments with `@claude` don't trigger the Claude workflow due to GitHub's security restrictions.

## Problem

GitHub prevents workflows triggered by `GITHUB_TOKEN` from triggering other workflows to avoid infinite loops. Even when using a Personal Access Token (PAT), comments created from within a GitHub Actions workflow are still identified as coming from `github-actions[bot]`.

## Solution

Implemented a two-step approach using `workflow_dispatch`:

1. **Added `claude-manual-trigger.yml`**: A manually triggerable workflow that creates comments using a PAT
2. **Modified `linear-integration.yml`**: Now triggers the manual workflow via API instead of directly commenting

### How it works:

1. Linear workflow creates a visible comment (as github-actions[bot]) for transparency
2. If `CLAUDE_TRIGGER_TOKEN` is set, it triggers the manual workflow via `workflow_dispatch`
3. The manual workflow runs with the PAT and creates the comment as the token owner
4. This comment from a real user account successfully triggers the Claude workflow

## Requirements

- Create a Personal Access Token (PAT) from a real GitHub user account (not a bot)
- Add it as `CLAUDE_TRIGGER_TOKEN` secret in repository settings
- Token needs `repo` and `workflow` scopes

## Testing

After merging and setting up the PAT:
1. Trigger the Linear integration workflow
2. Verify that Claude workflow is triggered when the bot posts `@claude` comments

🤖 Generated with [Claude Code](https://claude.ai/code)