### PR TITLE
Enable automatic Claude triggering using Personal Access Token

### DIFF
--- a/.github/workflows/linear-pr-creation.yml
+++ b/.github/workflows/linear-pr-creation.yml
@@ -226,7 +226,14 @@ jobs:
                 
                 **Linear Issue:** [${identifier}](${{ github.event.client_payload.url }})
                 **Team ID:** ${{ github.event.client_payload.teamId }}
-                **Issue Number:** ${{ github.event.client_payload.number }}`,
+                **Issue Number:** ${{ github.event.client_payload.number }}
+                
+                ---
+                
+                ## 🤖 Claude Implementation
+                
+                Claude will be automatically triggered to implement this feature.
+                The implementation will begin shortly after PR creation.`,
                 head: process.env.BRANCH_NAME,
                 base: 'main'
               });
@@ -247,28 +254,32 @@ jobs:
               }
             }
 
-  add-claude-comment:
-    name: Add Claude implementation comment
+  trigger-claude-implementation:
+    name: Trigger Claude Implementation
     runs-on: ubuntu-latest
     needs: [validate-inputs, check-conditions, create-pr]
     if: needs.validate-inputs.outputs.is_valid == 'true' && needs.check-conditions.outputs.should_proceed == 'true'
     steps:
-      - name: Add Claude comment to PR
+      - name: Add Claude trigger comment using PAT
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.CLAUDE_TRIGGER_TOKEN }}
           script: |
             try {
+              const prNumber = ${{ needs.create-pr.outputs.pr_number }};
+              
+              // Add Claude trigger comment using PAT
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: ${{ needs.create-pr.outputs.pr_number }},
+                issue_number: prNumber,
                 body: '@claude implement this feature based on the PR description'
               });
               
-              console.log('Added Claude comment to PR #${{ needs.create-pr.outputs.pr_number }}');
+              console.log(`Successfully triggered Claude for PR #${prNumber} using PAT`);
             } catch (error) {
-              console.error('Error adding comment:', error.message);
-              core.warning(`Failed to add Claude comment: ${error.message}`);
+              console.error('Error triggering Claude:', error.message);
+              core.warning(`Failed to trigger Claude: ${error.message}. Make sure CLAUDE_TRIGGER_TOKEN is set and has proper permissions.`);
             }
 
   remove-linear-label:


### PR DESCRIPTION
- Replace bot comment with PAT-authenticated comment
- Use CLAUDE_TRIGGER_TOKEN secret for authentication
- Rename job to trigger-claude-implementation
- Update PR description to indicate automatic triggering
- Remove manual trigger instructions since automation works

This solves the GitHub security limitation where bot comments cannot trigger workflows. The PAT allows the comment to appear as a real user, successfully triggering Claude implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)